### PR TITLE
Specify a container name when using Podman

### DIFF
--- a/docs/Installation/podman.md
+++ b/docs/Installation/podman.md
@@ -11,5 +11,5 @@ Yacht is compatible with podman. In order to run a Yacht container in podman you
 
 ```bash
 podman volume create yacht
-podman run -v /var/run/podman/podman.sock:/var/run/docker.sock -v yacht:/config -p 8000:8000 --name -d ghcr.io/selfhostedpro/yacht:latest
+podman run -v /var/run/podman/podman.sock:/var/run/docker.sock -v yacht:/config -p 8000:8000 --name yacht -d ghcr.io/selfhostedpro/yacht:latest
 ```


### PR DESCRIPTION
A container name needs to be specified, otherwise you get the following error message.

```
Error: error running container create option: names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument
```