### PR TITLE
Improve instruction clarity for reverse proxy

### DIFF
--- a/docs/Advanced/proxy.md
+++ b/docs/Advanced/proxy.md
@@ -4,10 +4,13 @@ description: Reverse proxy setup instructions
 hide_table_of_contents: true
 id: Proxy
 ---
-To put Yacht behind a reverse proxy you'll need to enable websockets support as Logs, Stats, and the Dashboard use websockets. In Nginx Proxy Manager this is done by enabling "Websockets Support" for a standard nginx setup you'll need to add the following to your Yacht location block:
+To put Yacht behind a reverse proxy you'll need to enable websockets support as Logs, Stats, and the Dashboard use websockets.
 
-```conf
-proxy_http_version 1.1;
-proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection "Upgrade";
-```
+- In Nginx Proxy Manager this is done by enabling "Websockets Support".
+- For a standard nginx setup you'll need to add the following to your Yacht location block:
+
+  ```conf
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "Upgrade";
+  ```


### PR DESCRIPTION
Currently the two instructions are merged into one sentence, this pr makes it a bit clearer which is which.