### PR TITLE
Fix grammar mistakes in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ A web interface for managing docker containers with an emphasis on templating to
 
 ## Templates
 
-Currently Yacht is compatible with portainer templates. You'll add a template url in the "Add Template" settings. The the template will be read, separated into apps, and imported into the database. The apps associated with the templates are linked via a db relationship so when the template is removed, so are the apps associated with it. We store the template url as well so we can enable updating templates with a button press.
+Currently Yacht is compatible with portainer templates. You'll add a template url in the "Add Template" settings. The template will be read, separated into apps, and imported into the database. The apps associated with the templates are linked via a db relationship so when the template is removed, so are the apps associated with it. We store the template url as well so we can enable updating templates with a button press.
 
 We recommend starting with:
 


### PR DESCRIPTION
The word "the" was listed twice in a row in the introduction page.