### PR TITLE
Update gettingstarted.md

### DIFF
--- a/docs/Installation/gettingstarted.md
+++ b/docs/Installation/gettingstarted.md
@@ -16,7 +16,8 @@ docker run -d -p 8000:8000 -v /var/run/docker.sock:/var/run/docker.sock -v yacht
 
 After that you can access Yacht on port 8000 on your server in a web browser.
 
-_If you're using Yacht alongside portainer you'll want to change the 8000 on the left of the `:` to 8001, then it will be available on that port on your host._
+- _If you're using Yacht alongside portainer, you'll want to change the 8000 on the left of the `:` to 8001, then it will be available on that port on your host._
+- _If SELinux is enabled on the host, you'll need to pass the `--privileged` flag to docker when deploying Yacht._
 
 Once you're at the login page you can login with the username `admin@yacht.local` and the password `pass`.
 


### PR DESCRIPTION
Add notice regarding the use of `--privileged` flag with docker if SELinux is enabled on host. Change formatting of notices to bullet list.

If the `--privileged` flag is not passed to docker when SELinux is enabled on the host, there will be `401 Unauthorized` errors in the Yacht dashboard and no resources will be shown as the Vue front-end fails to connect to the API backend.

Example docker command:

`docker run --privileged ...`



Example errors:

`Internal Server Error: Error while fetching server API version: ('Connection aborted.', PermissionError(13, 'Permission denied'))`

`Failed to load resource: the server responded with a status of 401 (Unauthorized) | :8000/api/auth/me:1 `

`GET http://ip_addr:8000/api/apps/ 500 (Internal Server Error)`
